### PR TITLE
Add backtrace when PluginThread panics and don't panic in drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ name = "dqcsim"
 version = "0.0.1"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,6 +69,7 @@ rand = "0.6"
 rand_chacha = "0.1"
 num-complex = "0.2"
 is_executable = "0.1"
+backtrace = "0.3"
 structopt = { version = "0.2", optional = true }
 ansi_term = { version = "0.11", optional = true }
 clap = { version = "2.33", optional = true }


### PR DESCRIPTION
This fixes the double panic [here](https://github.com/mbrobbel/dqcsim/commit/65b81c90e51ba9c71e0fe61111afba265a17160e) by removing the panic in the drop of `PluginThread`. This also adds a backtrace for panics in a `PluginThread`.