### PR TITLE
Rust 1.3.5

### DIFF
--- a/cpp/test_raw_c/arb.cpp
+++ b/cpp/test_raw_c/arb.cpp
@@ -11,7 +11,7 @@ TEST(arb, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_ARB_DATA);
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {}\n        ),\n        args: []\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {},\n        ),\n        args: [],\n    },\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);
@@ -48,7 +48,7 @@ TEST(arb, json) {
   EXPECT_STREQ(dqcs_error_get(), "Invalid argument: expected value at line 1 column 1");
 
   // Check that the ArbData object is what we expect.
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {\n                String(\n                    \"hello\"\n                ): String(\n                    \"world\"\n                )\n            }\n        ),\n        args: []\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {\n                String(\n                    \"hello\",\n                ): String(\n                    \"world\",\n                ),\n            },\n        ),\n        args: [],\n    },\n)");
   EXPECT_STREQ(dqcs_arb_json_get(a), "{\"hello\":\"world\"}");
   EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 14);
   EXPECT_EQ(memcmp(cbor_buffer, "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF", 14), 0);
@@ -84,7 +84,7 @@ TEST(arb, cbor) {
   EXPECT_STREQ(dqcs_error_get(), "Invalid argument: unexpected code at offset 1");
 
   // Check that the ArbData object is what we expect.
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {\n                String(\n                    \"hello\"\n                ): String(\n                    \"world\"\n                )\n            }\n        ),\n        args: []\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {\n                String(\n                    \"hello\",\n                ): String(\n                    \"world\",\n                ),\n            },\n        ),\n        args: [],\n    },\n)");
   EXPECT_STREQ(dqcs_arb_json_get(a), "{\"hello\":\"world\"}");
   EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 14);
   EXPECT_EQ(memcmp(cbor_buffer, "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF", 14), 0);
@@ -148,7 +148,7 @@ TEST(arb, test1) {
   EXPECT_EQ(dqcs_arb_assign(b, a), dqcs_return_t::DQCS_SUCCESS) << "Unexpected error: " << dqcs_error_get();
 
   // Check the (massive) debug string.
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {}\n        ),\n        args: [\n            [\n                70,\n                105,\n                114,\n                115,\n                116,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                50,\n                110,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                51,\n                114,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                106,\n                5,\n                0,\n                0\n            ],\n            []\n        ]\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Object(\n            {},\n        ),\n        args: [\n            [\n                70,\n                105,\n                114,\n                115,\n                116,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                50,\n                110,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                51,\n                114,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                106,\n                5,\n                0,\n                0,\n            ],\n            [],\n        ],\n    },\n)");
 
   // Do some correct pops.
   char buf[9] = {33, 33, 33, 33, 33, 33, 33, 33, 0};
@@ -184,7 +184,7 @@ TEST(arb, test1) {
 
   // Check that the copy was not mutated.
   EXPECT_EQ(dqcs_arb_len(b), 5);
-  EXPECT_STREQ(dqcs_handle_dump(b), "ArbData(\n    ArbData {\n        json: Object(\n            {}\n        ),\n        args: [\n            [\n                70,\n                105,\n                114,\n                115,\n                116,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                50,\n                110,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                51,\n                114,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116\n            ],\n            [\n                106,\n                5,\n                0,\n                0\n            ],\n            []\n        ]\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(b), "ArbData(\n    ArbData {\n        json: Object(\n            {},\n        ),\n        args: [\n            [\n                70,\n                105,\n                114,\n                115,\n                116,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                50,\n                110,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                51,\n                114,\n                100,\n                32,\n                97,\n                114,\n                103,\n                117,\n                109,\n                101,\n                110,\n                116,\n            ],\n            [\n                106,\n                5,\n                0,\n                0,\n            ],\n            [],\n        ],\n    },\n)");
 
   // Try a no-return pop.
   EXPECT_EQ(dqcs_arb_pop(b), dqcs_return_t::DQCS_SUCCESS) << "Unexpected error: " << dqcs_error_get();

--- a/cpp/test_raw_c/cmd.cpp
+++ b/cpp/test_raw_c/cmd.cpp
@@ -11,7 +11,7 @@ TEST(cmd, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_ARB_CMD);
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbCmd(\n    ArbCmd {\n        interface_identifier: \"a\",\n        operation_identifier: \"b\",\n        data: ArbData {\n            json: Object(\n                {}\n            ),\n            args: []\n        }\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbCmd(\n    ArbCmd {\n        interface_identifier: \"a\",\n        operation_identifier: \"b\",\n        data: ArbData {\n            json: Object(\n                {},\n            ),\n            args: [],\n        },\n    },\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/cq.cpp
+++ b/cpp/test_raw_c/cq.cpp
@@ -11,7 +11,7 @@ TEST(cq, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_ARB_CMD_QUEUE);
-  EXPECT_STREQ(dqcs_handle_dump(a), "ArbCmdQueue(\n    []\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "ArbCmdQueue(\n    [],\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/gate.cpp
+++ b/cpp/test_raw_c/gate.cpp
@@ -16,7 +16,7 @@ TEST(gate, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_GATE);
-  EXPECT_STREQ(dqcs_handle_dump(a), "Gate(\n    Gate {\n        name: Some(\n            \"NOP\"\n        ),\n        targets: [],\n        controls: [],\n        measures: [],\n        matrix: [],\n        data: ArbData {\n            json: Object(\n                {}\n            ),\n            args: []\n        }\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "Gate(\n    Gate {\n        name: Some(\n            \"NOP\",\n        ),\n        targets: [],\n        controls: [],\n        measures: [],\n        matrix: [],\n        data: ArbData {\n            json: Object(\n                {},\n            ),\n            args: [],\n        },\n    },\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/meas.cpp
+++ b/cpp/test_raw_c/meas.cpp
@@ -11,7 +11,7 @@ TEST(meas, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_MEAS);
-  EXPECT_STREQ(dqcs_handle_dump(a), "QubitMeasurementResult(\n    QubitMeasurementResult {\n        qubit: QubitRef(\n            1\n        ),\n        value: One,\n        data: ArbData {\n            json: Object(\n                {}\n            ),\n            args: []\n        }\n    }\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "QubitMeasurementResult(\n    QubitMeasurementResult {\n        qubit: QubitRef(\n            1,\n        ),\n        value: One,\n        data: ArbData {\n            json: Object(\n                {},\n            ),\n            args: [],\n        },\n    },\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/mset.cpp
+++ b/cpp/test_raw_c/mset.cpp
@@ -11,7 +11,7 @@ TEST(mset, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_MEAS_SET);
-  EXPECT_STREQ(dqcs_handle_dump(a), "QubitMeasurementResultSet(\n    {}\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "QubitMeasurementResultSet(\n    {},\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/pcfg.cpp
+++ b/cpp/test_raw_c/pcfg.cpp
@@ -221,19 +221,19 @@ TEST(pcfg, env) {
   // Override a key.
   EXPECT_EQ(dqcs_pcfg_env_set(a, "hello", "there"), dqcs_return_t::DQCS_SUCCESS);
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\" }]");
+  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\", },]");
   if (s) free(s);
 
   // Delete a key, option A.
   EXPECT_EQ(dqcs_pcfg_env_set(a, "delete", NULL), dqcs_return_t::DQCS_SUCCESS);
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\" }, Remove { key: \"delete\" }]");
+  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\", }, Remove { key: \"delete\", },]");
   if (s) free(s);
 
   // Delete a key, option B.
   EXPECT_EQ(dqcs_pcfg_env_unset(a, "unset"), dqcs_return_t::DQCS_SUCCESS);
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\" }, Remove { key: \"delete\" }, Remove { key: \"unset\" }]");
+  EXPECT_STREQ(extract_array_from_dump("env:", s), "env: [ Set { key: \"hello\", value: \"there\", }, Remove { key: \"delete\", }, Remove { key: \"unset\", },]");
   if (s) free(s);
 
   // Some errors.
@@ -267,7 +267,7 @@ TEST(pcfg, init) {
   ASSERT_NE(b, 0u) << "Unexpected error: " << dqcs_error_get();
   EXPECT_EQ(dqcs_pcfg_init_cmd(a, b), dqcs_return_t::DQCS_SUCCESS);
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("init:", s), "init: [ ArbCmd { interface_identifier: \"a\", operation_identifier: \"b\", data: ArbData { json: Object( {} ), args: [] } }]");
+  EXPECT_STREQ(extract_array_from_dump("init:", s), "init: [ ArbCmd { interface_identifier: \"a\", operation_identifier: \"b\", data: ArbData { json: Object( {}, ), args: [], }, },]");
   if (s) free(s);
 
   // Some errors.
@@ -308,7 +308,7 @@ TEST(pcfg, tee) {
 
   // Check that the tee file configurations were added.
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\" }, TeeFileConfiguration { filter: Trace, file: \"trace\" }]");
+  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\", }, TeeFileConfiguration { filter: Trace, file: \"trace\", },]");
   if (s) free(s);
 
   // Check that we can't do silly things.

--- a/cpp/test_raw_c/qbset.cpp
+++ b/cpp/test_raw_c/qbset.cpp
@@ -11,7 +11,7 @@ TEST(qbset, sanity) {
 
   // Check that the handle is OK.
   EXPECT_EQ(dqcs_handle_type(a), dqcs_handle_type_t::DQCS_HTYPE_QUBIT_SET);
-  EXPECT_STREQ(dqcs_handle_dump(a), "QubitReferenceSet(\n    []\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "QubitReferenceSet(\n    [],\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);
@@ -69,7 +69,7 @@ TEST(qbset, test) {
   EXPECT_EQ(dqcs_handle_delete(it), dqcs_return_t::DQCS_SUCCESS);
 
   // The original set should still be intact.
-  EXPECT_STREQ(dqcs_handle_dump(a), "QubitReferenceSet(\n    [\n        QubitRef(\n            4\n        ),\n        QubitRef(\n            42\n        ),\n        QubitRef(\n            16\n        ),\n        QubitRef(\n            15\n        ),\n        QubitRef(\n            8\n        ),\n        QubitRef(\n            23\n        )\n    ]\n)");
+  EXPECT_STREQ(dqcs_handle_dump(a), "QubitReferenceSet(\n    [\n        QubitRef(\n            4,\n        ),\n        QubitRef(\n            42,\n        ),\n        QubitRef(\n            16,\n        ),\n        QubitRef(\n            15,\n        ),\n        QubitRef(\n            8,\n        ),\n        QubitRef(\n            23,\n        ),\n    ],\n)");
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test_raw_c/scfg.cpp
+++ b/cpp/test_raw_c/scfg.cpp
@@ -183,7 +183,7 @@ TEST(scfg, tee) {
 
   // Check that the tee file configurations were added.
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\" }, TeeFileConfiguration { filter: Trace, file: \"trace\" }]");
+  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\", }, TeeFileConfiguration { filter: Trace, file: \"trace\", },]");
   if (s) free(s);
 
   // Check that we can't do silly things.

--- a/cpp/test_raw_c/sim_special_start.cpp
+++ b/cpp/test_raw_c/sim_special_start.cpp
@@ -99,7 +99,7 @@ TEST(sim_special_start, start_wait_front) {
   SIM_FOOTER;
 
   EXPECT_EQ(cfg.join_handle_type, dqcs_handle_type_t::DQCS_HTYPE_PLUGIN_JOIN);
-  EXPECT_EQ(cfg.join_handle_dump, "PluginJoinHandle(\n    JoinHandle { .. }\n)");
+  EXPECT_EQ(cfg.join_handle_dump, "PluginJoinHandle(\n    JoinHandle { .. },\n)");
   EXPECT_EQ(cfg.retval, dqcs_return_t::DQCS_SUCCESS);
 }
 
@@ -137,7 +137,7 @@ TEST(sim_special_start, start_front) {
   SIM_FOOTER;
 
   EXPECT_EQ(cfg.join_handle_type, dqcs_handle_type_t::DQCS_HTYPE_PLUGIN_JOIN);
-  EXPECT_EQ(cfg.join_handle_dump, "PluginJoinHandle(\n    JoinHandle { .. }\n)");
+  EXPECT_EQ(cfg.join_handle_dump, "PluginJoinHandle(\n    JoinHandle { .. },\n)");
 }
 
 // Test starting the wrong type of plugin.

--- a/cpp/test_raw_c/tcfg.cpp
+++ b/cpp/test_raw_c/tcfg.cpp
@@ -120,7 +120,7 @@ TEST(tcfg, init) {
   ASSERT_NE(b, 0u) << "Unexpected error: " << dqcs_error_get();
   EXPECT_EQ(dqcs_tcfg_init_cmd(a, b), dqcs_return_t::DQCS_SUCCESS);
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("init_cmds:", s), "init_cmds: [ ArbCmd { interface_identifier: \"a\", operation_identifier: \"b\", data: ArbData { json: Object( {} ), args: [] } }]");
+  EXPECT_STREQ(extract_array_from_dump("init_cmds:", s), "init_cmds: [ ArbCmd { interface_identifier: \"a\", operation_identifier: \"b\", data: ArbData { json: Object( {}, ), args: [], }, },]");
   if (s) free(s);
 
   // Some errors.
@@ -163,7 +163,7 @@ TEST(tcfg, tee) {
 
   // Check that the tee file configurations were added.
   s = dqcs_handle_dump(a);
-  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\" }, TeeFileConfiguration { filter: Trace, file: \"trace\" }]");
+  EXPECT_STREQ(extract_array_from_dump("tee_files:", s), "tee_files: [ TeeFileConfiguration { filter: Warn, file: \"warnings\", }, TeeFileConfiguration { filter: Trace, file: \"trace\", },]");
   if (s) free(s);
 
   // Check that we can't do silly things.

--- a/python/dqcsim/tests/test_arb.py
+++ b/python/dqcsim/tests/test_arb.py
@@ -143,39 +143,40 @@ class Operations(unittest.TestCase):
 
     def test_handles(self):
         a = ArbData(b'a', b'b', b'c', b=3, c=4, d=5)._to_raw()
+        self.maxDiff = None
         self.assertEqual(str(a), """ArbData(
     ArbData {
         json: Object(
             {
                 String(
-                    "b"
+                    "b",
                 ): U64(
-                    3
+                    3,
                 ),
                 String(
-                    "c"
+                    "c",
                 ): U64(
-                    4
+                    4,
                 ),
                 String(
-                    "d"
+                    "d",
                 ): U64(
-                    5
-                )
-            }
+                    5,
+                ),
+            },
         ),
         args: [
             [
-                97
+                97,
             ],
             [
-                98
+                98,
             ],
             [
-                99
-            ]
-        ]
-    }
+                99,
+            ],
+        ],
+    },
 )""")
 
         ArbData(b'c', b'd', b'e', b=6, c=7, d=8)._to_raw(a)
@@ -184,34 +185,34 @@ class Operations(unittest.TestCase):
         json: Object(
             {
                 String(
-                    "b"
+                    "b",
                 ): U64(
-                    6
+                    6,
                 ),
                 String(
-                    "c"
+                    "c",
                 ): U64(
-                    7
+                    7,
                 ),
                 String(
-                    "d"
+                    "d",
                 ): U64(
-                    8
-                )
-            }
+                    8,
+                ),
+            },
         ),
         args: [
             [
-                99
+                99,
             ],
             [
-                100
+                100,
             ],
             [
-                101
-            ]
-        ]
-    }
+                101,
+            ],
+        ],
+    },
 )""")
 
         self.assertEqual(ArbData._from_raw(a), ArbData(b'c', b'd', b'e', b=6, c=7, d=8))

--- a/python/dqcsim/tests/test_cmd.py
+++ b/python/dqcsim/tests/test_cmd.py
@@ -51,35 +51,35 @@ class Tests(unittest.TestCase):
             json: Object(
                 {
                     String(
-                        "b"
+                        "b",
                     ): U64(
-                        3
+                        3,
                     ),
                     String(
-                        "c"
+                        "c",
                     ): U64(
-                        4
+                        4,
                     ),
                     String(
-                        "d"
+                        "d",
                     ): U64(
-                        5
-                    )
-                }
+                        5,
+                    ),
+                },
             ),
             args: [
                 [
-                    97
+                    97,
                 ],
                 [
-                    98
+                    98,
                 ],
                 [
-                    99
-                ]
-            ]
-        }
-    }
+                    99,
+                ],
+            ],
+        },
+    },
 )""")
 
         self.assertEqual(ArbCmd._from_raw(a_handle), a)

--- a/python/dqcsim/tests/test_cq.py
+++ b/python/dqcsim/tests/test_cq.py
@@ -9,7 +9,7 @@ class Tests(unittest.TestCase):
     def test_all(self):
         a = ArbCmdQueue._to_raw()
         self.assertEqual(str(a), """ArbCmdQueue(
-    []
+    [],
 )""")
         self.assertEqual(ArbCmdQueue._from_raw(a), [])
 
@@ -21,12 +21,12 @@ class Tests(unittest.TestCase):
             operation_identifier: "b",
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
-        }
-    ]
+                args: [],
+            },
+        },
+    ],
 )""")
         self.assertEqual(ArbCmdQueue._from_raw(a), [ArbCmd('a', 'b')])
 
@@ -38,22 +38,22 @@ class Tests(unittest.TestCase):
             operation_identifier: "b",
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
+                args: [],
+            },
         },
         ArbCmd {
             interface_identifier: "c",
             operation_identifier: "d",
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
-        }
-    ]
+                args: [],
+            },
+        },
+    ],
 )""")
         self.assertEqual(ArbCmdQueue._from_raw(a), [ArbCmd('a', 'b'), ArbCmd('c', 'd')])
 
@@ -65,22 +65,22 @@ class Tests(unittest.TestCase):
             operation_identifier: "b",
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
+                args: [],
+            },
         },
         ArbCmd {
             interface_identifier: "c",
             operation_identifier: "d",
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
-        }
-    ]
+                args: [],
+            },
+        },
+    ],
 )""")
         self.assertEqual(ArbCmdQueue._from_raw(a), [ArbCmd('a', 'b'), ArbCmd('c', 'd')])
 

--- a/python/dqcsim/tests/test_handle.py
+++ b/python/dqcsim/tests/test_handle.py
@@ -14,10 +14,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(h), """ArbData(
     ArbData {
         json: Object(
-            {}
+            {},
         ),
-        args: []
-    }
+        args: [],
+    },
 )""")
         self.assertEqual(repr(h), """Handle({})""".format(xh))
         self.assertEqual(h.get_type(), raw.DQCS_HTYPE_ARB_DATA)
@@ -41,10 +41,10 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(h), """ArbData(
     ArbData {
         json: Object(
-            {}
+            {},
         ),
-        args: []
-    }
+        args: [],
+    },
 )""")
         self.assertEqual(repr(h), """Handle({})""".format(xh))
         self.assertEqual(h.get_type(), raw.DQCS_HTYPE_ARB_DATA)

--- a/python/dqcsim/tests/test_meas.py
+++ b/python/dqcsim/tests/test_meas.py
@@ -48,42 +48,42 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a_handle), """QubitMeasurementResult(
     QubitMeasurementResult {
         qubit: QubitRef(
-            33
+            33,
         ),
         value: One,
         data: ArbData {
             json: Object(
                 {
                     String(
-                        "b"
+                        "b",
                     ): U64(
-                        3
+                        3,
                     ),
                     String(
-                        "c"
+                        "c",
                     ): U64(
-                        4
+                        4,
                     ),
                     String(
-                        "d"
+                        "d",
                     ): U64(
-                        5
-                    )
-                }
+                        5,
+                    ),
+                },
             ),
             args: [
                 [
-                    97
+                    97,
                 ],
                 [
-                    98
+                    98,
                 ],
                 [
-                    99
-                ]
-            ]
-        }
-    }
+                    99,
+                ],
+            ],
+        },
+    },
 )""")
         self.assertEqual(Measurement._from_raw(a_handle), a)
 
@@ -93,16 +93,16 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a_handle), """QubitMeasurementResult(
     QubitMeasurementResult {
         qubit: QubitRef(
-            42
+            42,
         ),
         value: Zero,
         data: ArbData {
             json: Object(
-                {}
+                {},
             ),
-            args: []
-        }
-    }
+            args: [],
+        },
+    },
 )""")
         self.assertEqual(Measurement._from_raw(a_handle), a)
 
@@ -112,16 +112,16 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a_handle), """QubitMeasurementResult(
     QubitMeasurementResult {
         qubit: QubitRef(
-            23
+            23,
         ),
         value: Undefined,
         data: ArbData {
             json: Object(
-                {}
+                {},
             ),
-            args: []
-        }
-    }
+            args: [],
+        },
+    },
 )""")
         self.assertEqual(Measurement._from_raw(a_handle), a)
 

--- a/python/dqcsim/tests/test_mset.py
+++ b/python/dqcsim/tests/test_mset.py
@@ -11,7 +11,7 @@ class Tests(unittest.TestCase):
 
         a = MeasurementSet._to_raw()
         self.assertEqual(str(a), """QubitMeasurementResultSet(
-    {}
+    {},
 )""")
         self.assertEqual(MeasurementSet._from_raw(a), [])
 
@@ -19,20 +19,20 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a), """QubitMeasurementResultSet(
     {
         QubitRef(
-            1
+            1,
         ): QubitMeasurementResult {
             qubit: QubitRef(
-                1
+                1,
             ),
             value: Zero,
             data: ArbData {
                 json: Object(
-                    {}
+                    {},
                 ),
-                args: []
-            }
-        }
-    }
+                args: [],
+            },
+        },
+    },
 )""")
         self.assertEqual(MeasurementSet._from_raw(a), [Measurement(1, 0)])
 

--- a/python/dqcsim/tests/test_qbset.py
+++ b/python/dqcsim/tests/test_qbset.py
@@ -8,7 +8,7 @@ class Tests(unittest.TestCase):
     def test_all(self):
         a = QubitSet._to_raw()
         self.assertEqual(str(a), """QubitReferenceSet(
-    []
+    [],
 )""")
         self.assertEqual(QubitSet._from_raw(a), [])
 
@@ -16,9 +16,9 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a), """QubitReferenceSet(
     [
         QubitRef(
-            1
-        )
-    ]
+            1,
+        ),
+    ],
 )""")
         self.assertEqual(QubitSet._from_raw(a), [1])
 
@@ -26,15 +26,15 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a), """QubitReferenceSet(
     [
         QubitRef(
-            1
+            1,
         ),
         QubitRef(
-            2
+            2,
         ),
         QubitRef(
-            3
-        )
-    ]
+            3,
+        ),
+    ],
 )""")
         self.assertEqual(QubitSet._from_raw(a), [1, 2, 3])
 
@@ -42,15 +42,15 @@ class Tests(unittest.TestCase):
         self.assertEqual(str(a), """QubitReferenceSet(
     [
         QubitRef(
-            1
+            1,
         ),
         QubitRef(
-            2
+            2,
         ),
         QubitRef(
-            3
-        )
-    ]
+            3,
+        ),
+    ],
 )""")
         self.assertEqual(QubitSet._from_raw(a), [1, 2, 3])
 

--- a/rust/src/core/common/log/proxy.rs
+++ b/rust/src/core/common/log/proxy.rs
@@ -56,7 +56,7 @@ impl<T: Sender<Item = LogRecord>> Log for LogProxy<T> {
 mod tests {
     use crate::common::log::{proxy::LogProxy, thread::LogThread, Log, Loglevel, LoglevelFilter};
 
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn proxy_level() {
         let log_thread = LogThread::spawn(


### PR DESCRIPTION
This makes the dqcsim crate compatible with the latest stable version of [Rust 1.3.5](https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html).