### PR TITLE
Make internal CBOR representation canonical

### DIFF
--- a/cpp/test/raw/arb.cpp
+++ b/cpp/test/raw/arb.cpp
@@ -48,8 +48,8 @@ TEST(arb, json) {
   // Check that the ArbData object is what we expect.
   EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Map(\n            {\n                Text(\n                    \"hello\",\n                ): Text(\n                    \"world\",\n                ),\n            },\n        ),\n        args: [],\n    },\n)");
   EXPECT_STREQ(dqcs_arb_json_get(a), "{\"hello\":\"world\"}");
-  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 14);
-  EXPECT_EQ(memcmp(cbor_buffer, "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF", 14), 0);
+  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 13);
+  EXPECT_EQ(memcmp(cbor_buffer, "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64", 13), 0);
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);
@@ -67,8 +67,8 @@ TEST(arb, cbor) {
   ASSERT_NE(a, 0u) << "Unexpected error: " << dqcs_error_get();
 
   // Check default.
-  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 2);
-  EXPECT_EQ(memcmp(cbor_buffer, "\xBF\xFF", 2), 0);
+  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 1);
+  EXPECT_EQ(memcmp(cbor_buffer, "\xA0", 1), 0);
 
   // Check proper object.
   EXPECT_EQ(dqcs_arb_cbor_set(a, "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF", 14), dqcs_return_t::DQCS_SUCCESS);
@@ -79,13 +79,13 @@ TEST(arb, cbor) {
 
   // Check improper object.
   EXPECT_EQ(dqcs_arb_cbor_set(a, "\xFF", 1), dqcs_return_t::DQCS_FAILURE);
-  EXPECT_STREQ(dqcs_error_get(), "Invalid argument: unexpected code at offset 1");
+  EXPECT_STREQ(dqcs_error_get(), "Invalid argument: invalid CBOR: unexpected break");
 
   // Check that the ArbData object is what we expect.
   EXPECT_STREQ(dqcs_handle_dump(a), "ArbData(\n    ArbData {\n        json: Map(\n            {\n                Text(\n                    \"hello\",\n                ): Text(\n                    \"world\",\n                ),\n            },\n        ),\n        args: [],\n    },\n)");
   EXPECT_STREQ(dqcs_arb_json_get(a), "{\"hello\":\"world\"}");
-  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 14);
-  EXPECT_EQ(memcmp(cbor_buffer, "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF", 14), 0);
+  EXPECT_EQ(dqcs_arb_cbor_get(a, cbor_buffer, 256), 13);
+  EXPECT_EQ(memcmp(cbor_buffer, "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64", 13), 0);
 
   // Delete handle.
   EXPECT_EQ(dqcs_handle_delete(a), dqcs_return_t::DQCS_SUCCESS);

--- a/cpp/test/wrap/arb.cpp
+++ b/cpp/test/wrap/arb.cpp
@@ -13,19 +13,19 @@ TEST(arb, json) {
   data.set_arb_json_string("{\"hello\": \"world\"}");
   EXPECT_ERROR(data.set_arb_json_string("invalid JSON"), "Invalid argument: expected value at line 1 column 1");
   EXPECT_EQ(data.get_arb_json_string(), "{\"hello\":\"world\"}");
-  EXPECT_EQ(data.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
+  EXPECT_EQ(data.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
 }
 
 // Test JSON access by means of CBOR objects.
 TEST(arb, cbor) {
   wrap::ArbData data;
-  EXPECT_EQ(data.get_arb_cbor_string(), "\xBF\xFF");
+  EXPECT_EQ(data.get_arb_cbor_string(), "\xA0");
   data.set_arb_cbor_string("\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
-  EXPECT_ERROR(data.set_arb_cbor_string("\xFF"), "Invalid argument: unexpected code at offset 1");
+  EXPECT_ERROR(data.set_arb_cbor_string("\xFF"), "Invalid argument: invalid CBOR: unexpected break");
   EXPECT_EQ(data.get_arb_json_string(), "{\"hello\":\"world\"}");
-  EXPECT_EQ(data.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
-  EXPECT_ERROR(data.set_arb_cbor_string("this is not CBOR"), "Invalid argument: EOF while parsing a value at offset 16");
-  EXPECT_EQ(data.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
+  EXPECT_EQ(data.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
+  EXPECT_ERROR(data.set_arb_cbor_string("this is not CBOR"), "Invalid argument: invalid CBOR: incomplete bytes/utf8");
+  EXPECT_EQ(data.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
 }
 
 // Test JSON access by means of `nlohmann::json` objects.

--- a/cpp/test/wrap/meas.cpp
+++ b/cpp/test/wrap/meas.cpp
@@ -11,12 +11,12 @@ TEST(meas, test) {
 
   EXPECT_EQ(a.get_qubit().get_index(), 33);
   EXPECT_EQ(a.get_value(), wrap::MeasurementValue::One);
-  EXPECT_EQ(a.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
+  EXPECT_EQ(a.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
 
   wrap::Measurement b(a);
   EXPECT_EQ(b.get_qubit().get_index(), 33);
   EXPECT_EQ(b.get_value(), wrap::MeasurementValue::One);
-  EXPECT_EQ(b.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
+  EXPECT_EQ(b.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
 
   b.set_qubit(wrap::QubitRef(25));
   b.set_value(wrap::MeasurementValue::Zero);
@@ -26,5 +26,5 @@ TEST(meas, test) {
   b = a;
   EXPECT_EQ(b.get_qubit().get_index(), 33);
   EXPECT_EQ(b.get_value(), wrap::MeasurementValue::One);
-  EXPECT_EQ(b.get_arb_cbor_string(), "\xBF\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64\xFF");
+  EXPECT_EQ(b.get_arb_cbor_string(), "\xA1\x65\x68\x65\x6C\x6C\x6F\x65\x77\x6F\x72\x6C\x64");
 }

--- a/rust/src/bindings/external/common/arb.rs
+++ b/rust/src/bindings/external/common/arb.rs
@@ -327,8 +327,7 @@ pub extern "C" fn dqcs_arb_assign(dest: dqcs_handle_t, src: dqcs_handle_t) -> dq
     api_return_none(|| {
         resolve!(src as &ArbData);
         resolve!(dest as &mut ArbData);
-        dest.set_cbor_unchecked(src.get_cbor());
-        dest.set_args(src.get_args());
+        dest.copy_from(src);
         Ok(())
     })
 }


### PR DESCRIPTION
CBOR allows for multiple different representations of the same object, for instance by permuting dictionary key-value order and a streaming vs length-known-in-advance format of sequence types. The CBOR crate we use also does not produce a single canonical output; it is at the very least dependent on dictionary order. That's nice and all for performance, but breaks the current equality check (or complicates potential hand-written implementations).

This change ensures that the CBOR is stored in a canonical way whenever it is mutated. We were doing a validity check there anyway, so this shouldn't be much slower.

This should fix #334.