### PR TITLE
Fix Y measurement in Python & C++ API

### DIFF
--- a/cpp/include/dqcsim_bits/wrap.hpp
+++ b/cpp/include/dqcsim_bits/wrap.hpp
@@ -4695,7 +4695,7 @@ namespace wrap {
      * ```C++
      * gate(GateMatrix::S(), q);
      * gate(GateMatrix::Z(), q);
-     * measure_z(q);
+     * measure_x(q);
      * gate(GateMatrix::S(), q);
      * ```
      *
@@ -4710,7 +4710,7 @@ namespace wrap {
     void measure_y(const QubitRef &q) {
       gate(GateMatrix::S(), q);
       gate(GateMatrix::Z(), q);
-      measure_z(q);
+      measure_x(q);
       gate(GateMatrix::S(), q);
     }
 
@@ -4724,7 +4724,7 @@ namespace wrap {
      * ```C++
      * for (q : qs) gate(GateMatrix::S(), q);
      * for (q : qs) gate(GateMatrix::Z(), q);
-     * measure_z(qs);
+     * measure_x(qs);
      * for (q : qs) gate(GateMatrix::S(), q);
      * ```
      *
@@ -4741,7 +4741,7 @@ namespace wrap {
       auto qs_vec = qs.copy_into_vector();
       for (auto &q : qs_vec) gate(GateMatrix::S(), q);
       for (auto &q : qs_vec) gate(GateMatrix::Z(), q);
-      measure_z(qs);
+      measure_x(qs);
       for (auto &q : qs_vec) gate(GateMatrix::S(), q);
     }
 

--- a/python/dqcsim/plugin/__init__.py
+++ b/python/dqcsim/plugin/__init__.py
@@ -680,7 +680,9 @@ class GateStreamSource(Plugin):
 
             s_gate(qubit)
             z_gate(qubit)
+            h_gate(qubit)
             measure(qubit)
+            h_gate(qubit)
             s_gate(qubit)
 
         This function takes either one or more qubits as its positional
@@ -690,8 +692,9 @@ class GateStreamSource(Plugin):
             qubits = list(qubits[0])
         for qubit in qubits:
             self.s_gate(qubit)
+        for qubit in qubits:
             self.z_gate(qubit)
-        self.measure(qubits)
+        self.measure_x(qubits)
         for qubit in qubits:
             self.s_gate(qubit)
 

--- a/python/dqcsim/tests/test_gate.py
+++ b/python/dqcsim/tests/test_gate.py
@@ -449,7 +449,6 @@ class Tests(unittest.TestCase):
         ])
 
         # measure_x(1, 2, 3)
-        # meas_y = H, meas_z, H
         self.assert_unitary(log.pop(0), [1+u], [
             0.707+0.000j,  0.707+0.000j,
             0.707+0.000j, -0.707+0.000j,
@@ -480,8 +479,15 @@ class Tests(unittest.TestCase):
         ])
 
         # measure_y(1, 2, 3)
-        # meas_y = S, Z, meas_z, S
         self.assert_unitary(log.pop(0), [1+u], [
+            1.000+0.000j, 0.000+0.000j,
+            0.000+0.000j, 0.000+1.000j,
+        ])
+        self.assert_unitary(log.pop(0), [2+u], [
+            1.000+0.000j, 0.000+0.000j,
+            0.000+0.000j, 0.000+1.000j,
+        ])
+        self.assert_unitary(log.pop(0), [3+u], [
             1.000+0.000j, 0.000+0.000j,
             0.000+0.000j, 0.000+1.000j,
         ])
@@ -490,25 +496,41 @@ class Tests(unittest.TestCase):
             0.000+0.000j, -1.000+0.000j,
         ])
         self.assert_unitary(log.pop(0), [2+u], [
-            1.000+0.000j, 0.000+0.000j,
-            0.000+0.000j, 0.000+1.000j,
+            1.000+0.000j,  0.000-0.000j,
+            0.000+0.000j, -1.000+0.000j,
+        ])
+        self.assert_unitary(log.pop(0), [3+u], [
+            1.000+0.000j,  0.000-0.000j,
+            0.000+0.000j, -1.000+0.000j,
+        ])
+        self.assert_unitary(log.pop(0), [1+u], [
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
         ])
         self.assert_unitary(log.pop(0), [2+u], [
-            1.000+0.000j,  0.000-0.000j,
-            0.000+0.000j, -1.000+0.000j,
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
         ])
         self.assert_unitary(log.pop(0), [3+u], [
-            1.000+0.000j, 0.000+0.000j,
-            0.000+0.000j, 0.000+1.000j,
-        ])
-        self.assert_unitary(log.pop(0), [3+u], [
-            1.000+0.000j,  0.000-0.000j,
-            0.000+0.000j, -1.000+0.000j,
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
         ])
         self.assertEqual(log.pop(0), {
             'cmd': 'measurement',
             'measures': [1+m, 2+m, 3+m],
         })
+        self.assert_unitary(log.pop(0), [1+u], [
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
+        ])
+        self.assert_unitary(log.pop(0), [2+u], [
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
+        ])
+        self.assert_unitary(log.pop(0), [3+u], [
+            0.707+0.000j,  0.707+0.000j,
+            0.707+0.000j, -0.707+0.000j,
+        ])
         self.assert_unitary(log.pop(0), [1+u], [
             1.000+0.000j, 0.000+0.000j,
             0.000+0.000j, 0.000+1.000j,


### PR DESCRIPTION
Caused by a misinterpretation of QX's implementation of measure Y when I first looked at it; instead of [S, Z, measZ, S], it does [S, Z, meas**X**, S], which is [S, Z, H, measZ, H, S]. Looking at it now, I'm not at all sure why it does [S, Z] instead of just S-dagger, but whatever.