### PR TITLE
Package libdqcsim.so in lib64 as well

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ on:
     - 'cpp/**'
     - '**/CMakeLists.txt'
     - 'python/**'
-    - '**/setup.py'
+    - 'setup.py'
 
 jobs:
   rust:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ on:
     - 'cpp/**'
     - '**/CMakeLists.txt'
     - 'python/**'
-    - '**/setup.py'
+    - 'setup.py'
 
 jobs:
   check:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ on:
     - '**/Cargo.toml'
     - 'Cargo.lock'
     - 'python/**'
-    - '**/setup.py'
+    - 'setup.py'
 
 jobs:
   test:

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,9 @@ setup(
         ] + include_files.pop('include', [])),
         ('lib', [
             output_dir + '/libdqcsim.' + ('so' if platform.system() == "Linux" else 'dylib')
+        ]),
+        ('lib64', [
+            output_dir + '/libdqcsim.' + ('so' if platform.system() == "Linux" else 'dylib')
         ])
     ] + list(include_files.items()),
 

--- a/setup.py
+++ b/setup.py
@@ -182,11 +182,14 @@ setup(
         ] + include_files.pop('include', [])),
         ('lib', [
             output_dir + '/libdqcsim.' + ('so' if platform.system() == "Linux" else 'dylib')
-        ]),
-        ('lib64', [
-            output_dir + '/libdqcsim.' + ('so' if platform.system() == "Linux" else 'dylib')
         ])
-    ] + list(include_files.items()),
+    ] + (
+        [
+            ('lib64', [
+                output_dir + '/libdqcsim.so'
+            ])
+        ] if platform.system() == "Linux" else []
+    ) + list(include_files.items()),
 
     packages = find_packages('python'),
     package_dir = {


### PR DESCRIPTION
This is an attempted workaround for pip being too stupid to install shared objects in the directory that an OS which distinguishes between lib and lib64 expects to find them in. Basically, we just dump a copy of the file in both places. CI and time will tell if this breaks other systems.

Of course the assumption is still that <pythonprefix>/lib[64] and <pythonprefix>/include are in the system's library and include search paths. Only the user can fix that if they're not. (we could potentially provide a script to fix that... though pip will not be aware of any symlinks or whatever created to do the fix, so they won't be uninstalled, and making such a script that actually works most of the time is a considerable effort)