### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Swig
       run: brew install swig
     - name: Install dependencies
-      run: python -m pip install wheel
+      run: python3 -m pip install -U setuptools wheel
     - name: Build wheel
       run: python3 setup.py bdist_wheel
     - uses: actions/upload-artifact@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+# [0.1.1] - 2020-01-23
+
+- Fix PyPi wheel upload
+
 # [0.1.0] - 2020-01-23
 
-Initial release
+- Initial release
 
+[0.1.1]: https://github.com/mbrobbel/dqcsim/releases/tag/0.1.1
 [0.1.0]: https://github.com/mbrobbel/dqcsim/releases/tag/0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
     cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
 
     project(dqcsim
-        VERSION 0.1.0
+        VERSION 0.1.1
         DESCRIPTION "C++ bindings for the Delft Quantum & Classical Simulator"
         LANGUAGES CXX
     )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "dqcsim"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/python/tools/Dockerfile
+++ b/python/tools/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y && \
 	./configure --without-pcre && \
 	make && \
 	make install && \
-	${PYBIN}/pip3 install auditwheel
+	${PYBIN}/pip3 install -U setuptools wheel auditwheel
 
 ENV PATH=$PATH:/root/.cargo/bin
 

--- a/python/tools/Dockerfile
+++ b/python/tools/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y && \
 	./configure --without-pcre && \
 	make && \
 	make install && \
-	${PYBIN}/pip3 install -U setuptools wheel auditwheel
+	${PYBIN}/pip3 install auditwheel
 
 ENV PATH=$PATH:/root/.cargo/bin
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dqcsim"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Quantum Computer Architectures, Quantum & Computer Engineering, QuTech, Delft University of Technology"]
 edition = '2018'
 build = "tools/build.rs"


### PR DESCRIPTION
Upload of wheels to PyPi failed. This is most likely the result of outdated `setuptools` and `wheel` packages on macOS jobs. This should fix that and prepare a new release.