### PR TITLE
Allow Python plugins to access gate ArbData

### DIFF
--- a/python/dqcsim/tests/null_backend.py
+++ b/python/dqcsim/tests/null_backend.py
@@ -7,13 +7,13 @@ class NullBackend(Backend):
     def handle_drop(self):
         self.trace('null backend dropped!')
 
-    def handle_unitary_gate(self, targets, matrix):
+    def handle_unitary_gate(self, targets, matrix, arb):
         pass
 
-    def handle_measurement_gate(self, qubits, matrix):
+    def handle_measurement_gate(self, qubits, matrix, arb):
         return [Measurement(qubit, 0) for qubit in qubits]
 
-    def handle_prepare_gate(self, targets, matrix):
+    def handle_prepare_gate(self, targets, matrix, arb):
         pass
 
     def handle_host_work_env(self):

--- a/python/dqcsim/tests/test_gate.py
+++ b/python/dqcsim/tests/test_gate.py
@@ -51,14 +51,14 @@ class TestBackendUnitary(Backend):
         super().__init__()
         self.call_log = []
 
-    def handle_unitary_gate(self, targets, matrix):
+    def handle_unitary_gate(self, targets, matrix, arb):
         self.call_log.append({
             'cmd': 'unitary',
             'targets': targets,
             'matrix': pickle.dumps(matrix),
         })
 
-    def handle_measurement_gate(self, measures, matrix):
+    def handle_measurement_gate(self, measures, matrix, arb):
         self.call_log.append({
             'cmd': 'measurement',
             'measures': measures,
@@ -66,7 +66,7 @@ class TestBackendUnitary(Backend):
         })
         return [Measurement(qubit, qubit % 2) for qubit in measures]
 
-    def handle_prepare_gate(self, targets, matrix):
+    def handle_prepare_gate(self, targets, matrix, arb):
         self.call_log.append({
             'cmd': 'prepare',
             'targets': targets,
@@ -104,7 +104,7 @@ class TestBackendUnitary(Backend):
 
 @plugin("Test backend plugin", "Test", "0.2")
 class TestBackendControlled(TestBackendUnitary):
-    def handle_controlled_gate(self, targets, controls, matrix):
+    def handle_controlled_gate(self, targets, controls, matrix, arb):
         self.call_log.append({
             'cmd': 'controlled',
             'targets': targets,
@@ -118,11 +118,11 @@ class NullOperator(Operator):
 
 @plugin("Test operator 1", "Test", "0.1")
 class Operator1(Operator):
-    def handle_unitary_gate(self, targets, matrix):
+    def handle_unitary_gate(self, targets, matrix, arb):
         self.trace('unitary: {} {}', targets, matrix)
         self.unitary([q+1 for q in targets], matrix)
 
-    def handle_measurement_gate(self, measures, matrix):
+    def handle_measurement_gate(self, measures, matrix, arb):
         self.trace('measurement: {}', measures)
         self.measure([q+2 for q in measures], basis=matrix)
 
@@ -135,15 +135,15 @@ class Operator2(Operator):
             [q+1 for q in measures],
             matrix, *args, **kwargs)
 
-    def handle_controlled_gate(self, targets, controls, matrix):
+    def handle_controlled_gate(self, targets, controls, matrix, arb):
         self.unitary([q+2 for q in targets], matrix, controls=[q+2 for q in controls])
 
 @plugin("Test operator 3", "Test", "0.1")
 class Operator3(Operator):
-    def handle_unitary_gate(self, targets, matrix):
+    def handle_unitary_gate(self, targets, matrix, arb):
         self.unitary([q+1 for q in targets], matrix)
 
-    def handle_controlled_gate(self, targets, controls, matrix):
+    def handle_controlled_gate(self, targets, controls, matrix, arb):
         self.unitary([q+2 for q in targets], matrix, controls=[q+2 for q in controls])
 
 

--- a/python/dqcsim/tests/test_gatestream_misc.py
+++ b/python/dqcsim/tests/test_gatestream_misc.py
@@ -43,7 +43,7 @@ class NullOperator(Operator):
 
 @plugin("Test operator 1", "Test", "0.1")
 class TestOperator1(NullOperator):
-    def handle_measurement_gate(self, measures, matrix):
+    def handle_measurement_gate(self, measures, matrix, arb):
         self.measure([q+1 for q in measures])
 
     def handle_measurement(self, measurement):
@@ -76,13 +76,13 @@ class TestOperator3(NullOperator):
 
 @plugin("Null backend plugin", "Test", "0.1")
 class NullBackend(Backend):
-    def handle_unitary_gate(self, targets, matrix):
+    def handle_unitary_gate(self, targets, matrix, arb):
         pass
 
-    def handle_measurement_gate(self, measures, matrix):
+    def handle_measurement_gate(self, measures, matrix, arb):
         return [Measurement(qubit, False) for qubit in measures]
 
-    def handle_prepare_gate(self, targets, matrix):
+    def handle_prepare_gate(self, targets, matrix, arb):
         pass
 
     def handle_upstream_a_b(self):


### PR DESCRIPTION
This is unfortunately a breaking change, because the operator/backend plugin callbacks receive an additional argument.